### PR TITLE
Apply appropriate concepts to APIs design

### DIFF
--- a/.locust/fireball-file-download.py
+++ b/.locust/fireball-file-download.py
@@ -9,11 +9,15 @@ class FireballClientUser(HttpUser):
     @task
     def download_file(self):
         # local_file_path = str(uuid.uuid4()) + ".dat"
-        local_file_path = "local-1000.dat"
+        source_file = "local-1000.dat"
         body = {
-                "localFile": local_file_path,
-                "remoteIp": "127.0.0.1",
-                "remotePort": 50711,
-                "remoteFile": "remote-1000.dat"
-            }
+          "source": {
+            "ip": "127.0.0.1",
+            "port": 50711,
+            "file": "remote-1000.dat"
+          },
+          "destination": {
+            "file": source_file
+          }
+        }
         self.client.post("/download", json=body)

--- a/.locust/fireball-file-download.py
+++ b/.locust/fireball-file-download.py
@@ -16,4 +16,4 @@ class FireballClientUser(HttpUser):
                 "remotePort": 50711,
                 "remoteFile": "remote-1000.dat"
             }
-        self.client.put("/download", json=body)
+        self.client.post("/download", json=body)

--- a/.locust/fireball-file-download.py
+++ b/.locust/fireball-file-download.py
@@ -20,4 +20,4 @@ class FireballClientUser(HttpUser):
             "file": source_file
           }
         }
-        self.client.post("/download", json=body)
+        self.client.post("/api/download", json=body)

--- a/.locust/fireball-file-upload.py
+++ b/.locust/fireball-file-upload.py
@@ -9,11 +9,15 @@ class FireballClientUser(HttpUser):
     @task
     def upload_file(self):
         # remote_file_path = str(uuid.uuid4()) + ".dat"
-        remote_file_path = "remote-1000.dat"
+        remote_file = "remote-1000.dat"
         body = {
-                "localFile": "local-1000.dat",
-                "remoteIp": "127.0.0.1",
-                "remotePort": 50711,
-                "remoteFile": remote_file_path
-            }
+          "source": {
+            "file": "local-1000.dat"
+          },
+          "destination": {
+            "ip": "127.0.0.1",
+            "port": 50711,
+            "file": remote_file
+          }
+        }
         self.client.post("/upload", json=body)

--- a/.locust/fireball-file-upload.py
+++ b/.locust/fireball-file-upload.py
@@ -20,4 +20,4 @@ class FireballClientUser(HttpUser):
             "file": remote_file
           }
         }
-        self.client.post("/upload", json=body)
+        self.client.post("/api/upload", json=body)

--- a/.locust/fireball-file-upload.py
+++ b/.locust/fireball-file-upload.py
@@ -16,4 +16,4 @@ class FireballClientUser(HttpUser):
                 "remotePort": 50711,
                 "remoteFile": remote_file_path
             }
-        self.client.put("/upload", json=body)
+        self.client.post("/upload", json=body)

--- a/.script/linux/shell.sh
+++ b/.script/linux/shell.sh
@@ -5,6 +5,6 @@ git clone https://github.com/joosing/fireball.git
 cd fireball
 chmod 744 mvnw
 ./mvnw clean package -DskipTests
-java -Dfireball.server.root-path="/app/files" -Dfireball.client.root-path="/app/files"  -jar ./target/fireball-0.0.1.jar &
+java -Dfile.server.root="/app/files" -Dfile.client.root="/app/files"  -jar ./target/fireball-0.0.1.jar &
 
 # -XX:MaxDirectMemorySize=3g

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cd fireball
 RUN ./mvnw dependency:resolve
 RUN ./mvnw clean package -DskipTests
 
-ENTRYPOINT java -Dfireball.server.root-path="/app/files" -Dfireball.client.root-path="/app/files" -jar ./target/fireball-0.0.1.final.jar
+ENTRYPOINT java -Dfile.server.root="/app/files" -Dfile.client.root="/app/files" -jar ./target/fireball-0.0.1.final.jar
 
 # I have encountered the error "/bin/sh: 1: ./mvnw: not found" while building a docker image
 # This happens when Windows OS uses "\r\n" as an internal newline in the mvnw file

--- a/src/main/java/io/fireball/controller/FileClientController.java
+++ b/src/main/java/io/fireball/controller/FileClientController.java
@@ -1,6 +1,7 @@
 package io.fireball.controller;
 
-import io.fireball.dto.FileTransferDto;
+import io.fireball.dto.FileDownloadDto;
+import io.fireball.dto.FileUploadDto;
 import io.fireball.service.FileClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,14 +17,14 @@ public class FileClientController {
     private final FileClient fileClient;
 
     @PostMapping("/download")
-    public ResponseEntity<Void> downloadFile(@RequestBody FileTransferDto fileTransferDto) throws Exception {
-        fileClient.downloadFile(fileTransferDto);
+    public ResponseEntity<Void> downloadFileNew(@RequestBody FileDownloadDto spec) throws Exception {
+        fileClient.downloadFile(spec);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/upload")
-    public ResponseEntity<Void> uploadFile(@RequestBody FileTransferDto fileTransferDto) throws Exception {
-        fileClient.uploadFile(fileTransferDto);
+    public ResponseEntity<Void> uploadFile(@RequestBody FileUploadDto spec) throws Exception {
+        fileClient.uploadFile(spec);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/io/fireball/controller/FileClientController.java
+++ b/src/main/java/io/fireball/controller/FileClientController.java
@@ -5,7 +5,7 @@ import io.fireball.service.FileClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class FileClientController {
     private final FileClient fileClient;
 
-    @PutMapping("/download")
+    @PostMapping("/download")
     public ResponseEntity<Void> downloadFile(@RequestBody FileTransferDto fileTransferDto) throws Exception {
         fileClient.downloadFile(fileTransferDto);
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/upload")
+    @PostMapping("/upload")
     public ResponseEntity<Void> uploadFile(@RequestBody FileTransferDto fileTransferDto) throws Exception {
         fileClient.uploadFile(fileTransferDto);
         return ResponseEntity.ok().build();

--- a/src/main/java/io/fireball/dto/FileDownloadDto.java
+++ b/src/main/java/io/fireball/dto/FileDownloadDto.java
@@ -1,0 +1,15 @@
+package io.fireball.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@RequiredArgsConstructor
+@Getter
+@ToString
+@Accessors(fluent = true)
+public class FileDownloadDto {
+    private final RemoteFileDto source;
+    private final LocalFileDto destination;
+}

--- a/src/main/java/io/fireball/dto/FileUploadDto.java
+++ b/src/main/java/io/fireball/dto/FileUploadDto.java
@@ -1,0 +1,13 @@
+package io.fireball.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+@RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class FileUploadDto {
+    private final LocalFileDto source;
+    private final RemoteFileDto destination;
+}

--- a/src/main/java/io/fireball/dto/LocalFileDto.java
+++ b/src/main/java/io/fireball/dto/LocalFileDto.java
@@ -1,0 +1,17 @@
+package io.fireball.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+@ToString
+public class LocalFileDto {
+    private final String file;
+
+    public LocalFileDto(@JsonProperty("file") String file) {
+        this.file = file;
+    }
+}

--- a/src/main/java/io/fireball/dto/RemoteFileDto.java
+++ b/src/main/java/io/fireball/dto/RemoteFileDto.java
@@ -1,0 +1,16 @@
+package io.fireball.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+@ToString
+@RequiredArgsConstructor
+public class RemoteFileDto {
+    private final String ip;
+    private final int port;
+    private final String file;
+}

--- a/src/main/java/io/fireball/environment/RootPathEnvironment.java
+++ b/src/main/java/io/fireball/environment/RootPathEnvironment.java
@@ -17,20 +17,20 @@ import java.io.IOException;
 @Getter
 @Accessors(fluent = true)
 public class RootPathEnvironment {
-    @Value("${fireball.client.root-path}")
+    @Value("${file.client.root}")
     private String clientRootPath;
-    @Value("${fireball.server.root-path}")
+    @Value("${file.server.root}")
     private String serverRootPath;
 
     @PostConstruct
     public void configure() throws IOException {
         if (StringUtils.isBlank(clientRootPath)) {
             throw new RuntimeException("You must set the client side root directory." +
-                    "Like that: -Dfireball.client.root-path=/some/path)");
+                    "Like that: -Dfile.client.root=/some/path)");
         }
         if (StringUtils.isBlank(serverRootPath)) {
             throw new RuntimeException("You must set the server side root directory." +
-                    "Like that: -Dfireball.server.root-path=/some/path)");
+                    "Like that: -Dfile.server.root=/some/path)");
         }
 
         FileUtils.forceMkdir(new File(clientRootPath));

--- a/src/main/java/io/fireball/message/UserFileDownloadRequest.java
+++ b/src/main/java/io/fireball/message/UserFileDownloadRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Builder
 @Getter
 public class UserFileDownloadRequest implements UserRequest {
-    private final String srcFilePath;
-    private final String dstFilePath;
+    private final String srcFile;
+    private final String dstFile;
 }

--- a/src/main/java/io/fireball/message/UserFileUploadRequest.java
+++ b/src/main/java/io/fireball/message/UserFileUploadRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Builder
 @Getter
 public class UserFileUploadRequest implements UserRequest {
-    private final String srcFilePath;
-    private final String dstFilePath;
+    private final String srcFile;
+    private final String dstFile;
 }

--- a/src/main/java/io/fireball/processor/FileDownloadOutboundRequestProcessor.java
+++ b/src/main/java/io/fireball/processor/FileDownloadOutboundRequestProcessor.java
@@ -15,8 +15,8 @@ public class FileDownloadOutboundRequestProcessor implements OutboundRequestProc
     public List<ProtocolMessage> process(UserRequest message) {
         var userRequest = (UserFileDownloadRequest) message;
         return List.of(FileDownloadRequest.builder()
-                .srcFilePath(userRequest.getSrcFilePath())
-                .dstFilePath(userRequest.getDstFilePath())
+                .srcFilePath(userRequest.getSrcFile())
+                .dstFilePath(userRequest.getDstFile())
                 .build());
     }
 }

--- a/src/main/java/io/fireball/processor/FileUploadOutboundRequestProcessor.java
+++ b/src/main/java/io/fireball/processor/FileUploadOutboundRequestProcessor.java
@@ -22,8 +22,8 @@ public class FileUploadOutboundRequestProcessor implements OutboundRequestProces
         var uploadRequest = (UserFileUploadRequest) message;
 
         // 파일 청크 분할 생성
-        var srcFilePath = Path.of(rootPath, uploadRequest.getSrcFilePath()).normalize().toString();
-        var dstFilePath = uploadRequest.getDstFilePath();
+        var srcFilePath = Path.of(rootPath, uploadRequest.getSrcFile()).normalize().toString();
+        var dstFilePath = uploadRequest.getDstFile();
         var fileChunks = fileTransferProcessor.process(srcFilePath, dstFilePath, chunkSize);
 
         // 명시적 요청 헤더

--- a/src/main/java/io/fireball/runner/FileServerRunner.java
+++ b/src/main/java/io/fireball/runner/FileServerRunner.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ExecutionException;
 @Component
 @RequiredArgsConstructor
 public class FileServerRunner {
-    @Value("${fireball.server.port}")
+    @Value("${file.server.port}")
     private Integer port;
     private final FilerServer server;
 

--- a/src/main/java/io/fireball/service/FileClient.java
+++ b/src/main/java/io/fireball/service/FileClient.java
@@ -1,8 +1,9 @@
 package io.fireball.service;
 
-import io.fireball.dto.FileTransferDto;
+import io.fireball.dto.FileDownloadDto;
+import io.fireball.dto.FileUploadDto;
 
 public interface FileClient {
-    void downloadFile(FileTransferDto fileTransferDto) throws Exception;
-    void uploadFile(FileTransferDto fileTransferDto) throws Exception;
+    void downloadFile(FileDownloadDto spec) throws Exception;
+    void uploadFile(FileUploadDto spec) throws Exception;
 }

--- a/src/main/java/io/fireball/service/TcpFileClient.java
+++ b/src/main/java/io/fireball/service/TcpFileClient.java
@@ -1,6 +1,7 @@
 package io.fireball.service;
 
-import io.fireball.dto.FileTransferDto;
+import io.fireball.dto.FileDownloadDto;
+import io.fireball.dto.FileUploadDto;
 import io.fireball.eventloop.ClientEventLoopGroupManager;
 import io.fireball.handler.duplex.RequestResultChecker;
 import io.fireball.message.UserFileDownloadRequest;
@@ -29,23 +30,23 @@ public class TcpFileClient implements FileClient {
     }
 
     @Override
-    public void downloadFile(FileTransferDto spec) throws ExecutionException
+    public void downloadFile(FileDownloadDto spec) throws ExecutionException
             , InterruptedException, TimeoutException {
         var downloadRequest = UserFileDownloadRequest.builder()
-                .srcFilePath(spec.getRemoteFile())
-                .dstFilePath(spec.getLocalFile())
+                .srcFile(spec.source().file())
+                .dstFile(spec.destination().file())
                 .build();
-        requestTemplate(downloadRequest, spec.getRemoteIp(), spec.getRemotePort());
+        requestTemplate(downloadRequest, spec.source().ip(), spec.source().port());
     }
 
     @Override
-    public void uploadFile(FileTransferDto spec) throws ExecutionException,
+    public void uploadFile(FileUploadDto spec) throws ExecutionException,
             InterruptedException, TimeoutException {
         var uploadRequest = UserFileUploadRequest.builder()
-                .srcFilePath(spec.getLocalFile())
-                .dstFilePath(spec.getRemoteFile())
+                .srcFile(spec.source().file())
+                .dstFile(spec.destination().file())
                 .build();
-        requestTemplate(uploadRequest, spec.getRemoteIp(), spec.getRemotePort());
+        requestTemplate(uploadRequest, spec.destination().ip(), spec.destination().port());
     }
 
     private void requestTemplate(UserRequest request, String ip, int port) throws ExecutionException

--- a/src/main/java/io/fireball/specification/channel/FileClientSpec.java
+++ b/src/main/java/io/fireball/specification/channel/FileClientSpec.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Accessors(fluent = true)
 @Component
 public class FileClientSpec {
-    @Value("${fireball.client.root-path}")
+    @Value("${file.client.root}")
     private String rootPath;
     private final int idleDetectionSeconds = 3;
     private final int chunkSize = 1024 * 1024 * 5;

--- a/src/main/java/io/fireball/specification/channel/FileServerSpec.java
+++ b/src/main/java/io/fireball/specification/channel/FileServerSpec.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @Accessors(fluent = true)
 @Component
 public class FileServerSpec {
-    @Value("${fireball.server.root-path}")
+    @Value("${file.server.root}")
     private String rootPath;
     private final int idleDetectionSeconds = 3;
     private final int chunkSize = 1024 * 1024 * 5;

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -4,5 +4,5 @@ spring.servlet.multipart.max-file-size=2048MB
 spring.servlet.multipart.max-request-size=2048MB
 
 # fireball
-fireball.client.root-path=./files
-fireball.server.root-path=./files
+file.client.root=./files
+file.server.root=./files

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,9 @@
 server.port=58080
+server.servlet.context-path=/api
 
 # server
-fireball.server.root-path=
-fireball.server.port=50711
+file.server.root=
+file.server.port=50711
 
 # client
-fireball.client.root-path=
+file.client.root=

--- a/src/test/java/io/fireball/integration/FileTransferTest.java
+++ b/src/test/java/io/fireball/integration/FileTransferTest.java
@@ -57,12 +57,16 @@ public class FileTransferTest extends RestAssuredTest {
                     .contentType("application/json")
                     .body("""
                             {
-                                "localFile": "%s",
-                                "remoteIp": "%s",
-                                "remotePort": "%s",
-                                "remoteFile": "%s"
+                              "source": {
+                                "ip": "%s",
+                                "port": %d,
+                                "file": "%s"
+                              },
+                              "destination": {
+                                "file": "%s"
+                              }
                             }
-                            """.formatted(clientFileName, "127.0.0.1", FILE_SERVER_PORT, serverFileName))
+                            """.formatted("127.0.0.1", FILE_SERVER_PORT, serverFileName, clientFileName))
                 .when()
                     .post("/download")
                 .then()
@@ -89,10 +93,14 @@ public class FileTransferTest extends RestAssuredTest {
                     .contentType("application/json")
                     .body("""
                             {
-                                "localFile": "%s",
-                                "remoteIp": "%s",
-                                "remotePort": "%s",
-                                "remoteFile": "%s"
+                              "source": {
+                                "file": "%s"
+                              },
+                              "destination": {
+                                "ip": "%s",
+                                "port": %d,
+                                "file": "%s"
+                              }
                             }
                             """.formatted(clientFileName, "127.0.0.1", FILE_SERVER_PORT, serverFileName))
                 .when()

--- a/src/test/java/io/fireball/integration/FileTransferTest.java
+++ b/src/test/java/io/fireball/integration/FileTransferTest.java
@@ -64,7 +64,7 @@ public class FileTransferTest extends RestAssuredTest {
                             }
                             """.formatted(clientFileName, "127.0.0.1", FILE_SERVER_PORT, serverFileName))
                 .when()
-                    .put("/download")
+                    .post("/download")
                 .then()
                     .assertThat()
                     .log().all()
@@ -96,7 +96,7 @@ public class FileTransferTest extends RestAssuredTest {
                             }
                             """.formatted(clientFileName, "127.0.0.1", FILE_SERVER_PORT, serverFileName))
                 .when()
-                    .put("/upload")
+                    .post("/upload")
                 .then()
                     .assertThat()
                     .log().all()

--- a/src/test/java/io/fireball/integration/FileTransferTest.java
+++ b/src/test/java/io/fireball/integration/FileTransferTest.java
@@ -68,7 +68,7 @@ public class FileTransferTest extends RestAssuredTest {
                             }
                             """.formatted("127.0.0.1", FILE_SERVER_PORT, serverFileName, clientFileName))
                 .when()
-                    .post("/download")
+                    .post("/api/download")
                 .then()
                     .assertThat()
                     .log().all()
@@ -104,7 +104,7 @@ public class FileTransferTest extends RestAssuredTest {
                             }
                             """.formatted(clientFileName, "127.0.0.1", FILE_SERVER_PORT, serverFileName))
                 .when()
-                    .post("/upload")
+                    .post("/api/upload")
                 .then()
                     .assertThat()
                     .log().all()


### PR DESCRIPTION
see issue #42 : The design of APIs doesn't provide the right concepts

# Implement
- Change from a PUT method to a POST method.
- Separate DTOs for downloads and uploads.
- Bridges the concepts of source and destination from the user perspective and local and remote from the service implementer perspective.
- Set the server.servlet.context-path property to "/api".
- Rename the property setting.
  - fireball.server.root-path -> file.server.root
  - fireball.server.port -> file.server.port
  - fireball.client.root-path -> file.client.root